### PR TITLE
Add ical dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To make the development of skills easier, we have created the ASK SDK for Node.j
 3.  Once you have the source downloaded, node.js installed and npm updated, you are ready to install the ASK-SDK. Install this in the same directory as your Calendar Reader src/index.js file you downloaded earlier. Change the directory to the src directory of your skill, and then in the command line, type:
  
     ```
-    npm install --save alexa-sdk
+    npm install --save alexa-sdk ical
     ```
     Once this is installed you will need to include the **node_modules** directory with the source code for your skill when you compress the src for uploading to AWS Lambda. Let's do this with the example.
     

--- a/src/package.json
+++ b/src/package.json
@@ -14,6 +14,7 @@
   "author": "Amazon.com",
   "license": "Apache-2.0",
   "dependencies": {
-    "alexa-sdk": "^1.0.0"
+    "alexa-sdk": "^1.0.0",
+    "ical": "^0.5.0"
   }
 }


### PR DESCRIPTION
Fix error below when run on lambda function:

```
Unable to import module 'index': Error
at Function.Module._resolveFilename (module.js:325:15)
at Function.Module._load (module.js:276:25)
at Module.require (module.js:353:17)
at require (internal/module.js:12:17)
at Object.<anonymous> (/var/task/index.js:2:12)
at Module._compile (module.js:409:26)
at Object.Module._extensions..js (module.js:416:10)
at Module.load (module.js:343:32)
at Function.Module._load (module.js:300:12)
at Module.require (module.js:353:17)
```