### PR TITLE
appId never set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -262,7 +262,7 @@ var descriptionHandlers = Alexa.CreateStateHandler(states.DESCRIPTION, {
 // register handlers
 exports.handler = function (event, context, callback) {
     alexa = Alexa.handler(event, context);
-    alexa.AppId = APP_ID;
+    alexa.appId = APP_ID;
     alexa.registerHandlers(newSessionHandlers, startSearchHandlers, descriptionHandlers);
     alexa.execute();
 };


### PR DESCRIPTION
The application ID is not set due to case sensitivity, thus the check never occurs. Need to set `alexa.appId = APP_ID` instead of `alexa.AppId = APP_ID` in the `exports.handler`.