### PR TITLE
Protect against missing ICS properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -270,6 +270,8 @@ exports.handler = function (event, context, callback) {
 
 // Remove HTML tags from string
 function removeTags(str) {
+    if (!str) // some iCal properties may not exist
+        return str;
     return str.replace(/<(?:.|\n)*?>/gm, '');
 }
 


### PR DESCRIPTION
If the Summary, Location, or Description do not exist, don't try to remove tags.