### PR TITLE
Say only first three, no more

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,7 @@ var startSearchHandlers = Alexa.CreateStateHandler(states.SEARCHMODE, {
                         output += scheduledEventMessage;
 
                         if (relevantEvents.length > 1) {
-                            output += utils.format(firstThreeMessage, relevantEvents.length);
+                            output += utils.format(firstThreeMessage, relevantEvents.length > 3 ? 3 : relevantEvents.length);
                         }
 
                         if (relevantEvents[0] != null) {


### PR DESCRIPTION
If more than three events in a date range, only say the first three, not the actual number of events when the preceding text says first three.